### PR TITLE
add private APIM example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LCAF_ENV_FILE = .lcafenv
 # Source repository for repo manifests
 REPO_MANIFESTS_URL ?= https://github.com/launchbynttdata/launch-common-automation-framework.git
 # Branch of source repository for repo manifests. Other tags not currently supported.
-REPO_BRANCH ?= refs/tags/1.0.0
+REPO_BRANCH ?= refs/tags/1.7.1
 # Path to seed manifest in repository referenced in REPO_MANIFESTS_URL
 REPO_MANIFEST ?= manifests/terraform_modules/seed/manifest.xml
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tf-azurerm-module_primitive-api_management
+# tf-azurerm-module_reference-api_management
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: CC BY-NC-ND 4.0](https://img.shields.io/badge/License-CC_BY--NC--ND_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-nd/4.0/)
@@ -112,7 +112,7 @@ If `make check` target is successful, developer is good to commit the code to pr
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.67 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.117 |
 
 ## Providers
 

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -1,4 +1,4 @@
-# public_serverless
+# private
 
 Please set a provider block with the following, to avoid soft-deletes of the APIM instance which can cause problems with the tests
 ```
@@ -19,7 +19,7 @@ provider "azurerm" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.67 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.117 |
 
 ## Providers
 

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -1,0 +1,77 @@
+# public_serverless
+
+Please set a provider block with the following, to avoid soft-deletes of the APIM instance which can cause problems with the tests
+```
+provider "azurerm" {
+  features {
+    api_management {
+      purge_soft_delete_on_destroy = true
+      recover_soft_deleted         = true
+    }
+  }
+}
+```
+
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.67 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 1.0 |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.0 |
+| <a name="module_virtual_network"></a> [virtual\_network](#module\_virtual\_network) | terraform.registry.launch.nttdata.com/module_primitive/virtual_network/azurerm | ~> 3.0 |
+| <a name="module_apim"></a> [apim](#module\_apim) | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_product_family"></a> [product\_family](#input\_product\_family) | (Required) Name of the product family for which the resource is created.<br>    Example: org\_name, department\_name. | `string` | `"dso"` | no |
+| <a name="input_product_service"></a> [product\_service](#input\_product\_service) | (Required) Name of the product service for which the resource is created.<br>    For example, backend, frontend, middleware etc. | `string` | `"apim"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment in which the resource should be provisioned like dev, qa, prod etc. | `string` | `"dev"` | no |
+| <a name="input_environment_number"></a> [environment\_number](#input\_environment\_number) | The environment count for the respective environment. Defaults to 000. Increments in value of 1 | `string` | `"000"` | no |
+| <a name="input_resource_number"></a> [resource\_number](#input\_resource\_number) | The resource count for the respective resource. Defaults to 000. Increments in value of 1 | `string` | `"000"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Azure Region in which the infra needs to be provisioned | `string` | `"eastus"` | no |
+| <a name="input_resource_names_map"></a> [resource\_names\_map](#input\_resource\_names\_map) | A map of key to resource\_name that will be used by tf-launch-module\_library-resource\_name to generate resource names | <pre>map(object(<br>    {<br>      name       = string<br>      max_length = optional(number, 60)<br>    }<br>  ))</pre> | <pre>{<br>  "resource_group": {<br>    "max_length": 60,<br>    "name": "rg"<br>  },<br>  "virtual_network": {<br>    "name": "vnet"<br>  }<br>}</pre> | no |
+| <a name="input_address_prefix"></a> [address\_prefix](#input\_address\_prefix) | The address space that is used by the virtual network. | `string` | `"10.6.0.0/16"` | no |
+| <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | String consisting of two parts separated by an underscore. The fist part is the name, valid values include: Developer,<br>    Basic, Standard and Premium. The second part is the capacity. Default is Developer\_1. | `string` | `"Developer_1"` | no |
+| <a name="input_publisher_name"></a> [publisher\_name](#input\_publisher\_name) | The name of publisher/company. | `string` | n/a | yes |
+| <a name="input_publisher_email"></a> [publisher\_email](#input\_publisher\_email) | The email of publisher/company. | `string` | n/a | yes |
+| <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Should the API Management Service be accessible from the public internet?<br>    This option is applicable only to the Management plane, not the API gateway or Developer portal.<br>    It is required to be true on the creation.<br>    For sku=Developer/Premium and network\_type=Internal, it must be true.<br>    It can only be set to false if there is at least one approve private endpoint connection. | `bool` | `true` | no |
+| <a name="input_virtual_network_type"></a> [virtual\_network\_type](#input\_virtual\_network\_type) | The type of virtual network you want to use, valid values include: None, External, Internal.<br>    External and Internal are only supported in the SKUs - Premium and Developer | `string` | `"None"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_api_management_name"></a> [api\_management\_name](#output\_api\_management\_name) | The name of the API Management Service |
+| <a name="output_api_management_id"></a> [api\_management\_id](#output\_api\_management\_id) | The ID of the API Management Service |
+| <a name="output_api_management_additional_location"></a> [api\_management\_additional\_location](#output\_api\_management\_additional\_location) | Map listing gateway\_regional\_url and public\_ip\_addresses associated |
+| <a name="output_api_management_gateway_url"></a> [api\_management\_gateway\_url](#output\_api\_management\_gateway\_url) | The URL of the Gateway for the API Management Service |
+| <a name="output_api_management_gateway_regional_url"></a> [api\_management\_gateway\_regional\_url](#output\_api\_management\_gateway\_regional\_url) | The Region URL for the Gateway of the API Management Service |
+| <a name="output_api_management_management_api_url"></a> [api\_management\_management\_api\_url](#output\_api\_management\_management\_api\_url) | The URL for the Management API associated with this API Management service |
+| <a name="output_api_management_portal_url"></a> [api\_management\_portal\_url](#output\_api\_management\_portal\_url) | The URL for the Publisher Portal associated with this API Management service |
+| <a name="output_api_management_public_ip_addresses"></a> [api\_management\_public\_ip\_addresses](#output\_api\_management\_public\_ip\_addresses) | The Public IP addresses of the API Management Service |
+| <a name="output_api_management_private_ip_addresses"></a> [api\_management\_private\_ip\_addresses](#output\_api\_management\_private\_ip\_addresses) | The Private IP addresses of the API Management Service |
+| <a name="output_api_management_scm_url"></a> [api\_management\_scm\_url](#output\_api\_management\_scm\_url) | The URL for the SCM Endpoint associated with this API Management service |
+| <a name="output_api_management_identity"></a> [api\_management\_identity](#output\_api\_management\_identity) | The identity of the API Management |
+| <a name="output_public_ip_address"></a> [public\_ip\_address](#output\_public\_ip\_address) | n/a |
+| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -1,0 +1,85 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module "resource_names" {
+  source  = "terraform.registry.launch.nttdata.com/module_library/resource_name/launch"
+  version = "~> 1.0"
+
+  for_each = var.resource_names_map
+
+  logical_product_family  = var.product_family
+  logical_product_service = var.product_service
+  region                  = var.region
+  class_env               = var.environment
+  cloud_resource_type     = each.value.name
+  instance_env            = var.environment_number
+  maximum_length          = each.value.max_length
+  use_azure_region_abbr   = true
+}
+
+module "resource_group" {
+  source  = "terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm"
+  version = "~> 1.0"
+
+  name     = module.resource_names["resource_group"].minimal_random_suffix
+  location = var.region
+
+  tags = merge(var.tags, { resource_name = module.resource_names["resource_group"].standard })
+
+}
+
+module "virtual_network" {
+  source  = "terraform.registry.launch.nttdata.com/module_primitive/virtual_network/azurerm"
+  version = "~> 3.0"
+
+  resource_group_name = module.resource_group.name
+  vnet_name           = module.resource_names["virtual_network"].minimal_random_suffix
+  vnet_location       = var.region
+
+  address_space = [var.address_prefix]
+
+  subnets = {
+    "api-management-subnet" = {
+      prefix = var.address_prefix
+    }
+  }
+
+  tags = merge(var.tags, { resource_name = module.resource_names["virtual_network"].standard })
+
+  depends_on = [
+    module.resource_group,
+  ]
+}
+
+module "apim" {
+  source = "../.."
+
+  product_family     = var.product_family
+  product_service    = var.product_service
+  environment        = var.environment
+  environment_number = var.environment_number
+  resource_number    = var.resource_number
+  region             = var.region
+
+  sku_name        = var.sku_name
+  publisher_name  = var.publisher_name
+  publisher_email = var.publisher_email
+
+  public_network_access_enabled = var.public_network_access_enabled
+
+  virtual_network_type = var.virtual_network_type
+  virtual_network_configuration = [
+    module.virtual_network.subnet_name_id_map["api-management-subnet"]
+  ]
+
+  tags = var.tags
+}

--- a/examples/private/outputs.tf
+++ b/examples/private/outputs.tf
@@ -66,9 +66,9 @@ output "api_management_identity" {
 }
 
 output "public_ip_address" {
-  value = length(module.public_ip) > 0 ? module.public_ip[0].ip_address : null
+  value = module.apim.public_ip_address
 }
 
 output "resource_group_name" {
-  value = var.resource_group_name != null ? var.resource_group_name : module.resource_group[0].name
+  value = module.apim.resource_group_name
 }

--- a/examples/private/test.tfvars
+++ b/examples/private/test.tfvars
@@ -1,0 +1,5 @@
+sku_name        = "Developer_1"
+publisher_name  = "launchdso@nttdata.com"
+publisher_email = "launchdso@nttdata.com"
+
+virtual_network_type = "Internal"

--- a/examples/private/variables.tf
+++ b/examples/private/variables.tf
@@ -1,0 +1,123 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+variable "product_family" {
+  description = <<EOF
+    (Required) Name of the product family for which the resource is created.
+    Example: org_name, department_name.
+  EOF
+  type        = string
+  default     = "dso"
+}
+
+variable "product_service" {
+  description = <<EOF
+    (Required) Name of the product service for which the resource is created.
+    For example, backend, frontend, middleware etc.
+  EOF
+  type        = string
+  default     = "apim"
+}
+
+variable "environment" {
+  description = "Environment in which the resource should be provisioned like dev, qa, prod etc."
+  type        = string
+  default     = "dev"
+}
+
+variable "environment_number" {
+  description = "The environment count for the respective environment. Defaults to 000. Increments in value of 1"
+  type        = string
+  default     = "000"
+}
+
+variable "resource_number" {
+  description = "The resource count for the respective resource. Defaults to 000. Increments in value of 1"
+  type        = string
+  default     = "000"
+}
+
+variable "region" {
+  description = "Azure Region in which the infra needs to be provisioned"
+  type        = string
+  default     = "eastus"
+}
+
+variable "resource_names_map" {
+  description = "A map of key to resource_name that will be used by tf-launch-module_library-resource_name to generate resource names"
+  type = map(object(
+    {
+      name       = string
+      max_length = optional(number, 60)
+    }
+  ))
+  default = {
+    resource_group = {
+      name       = "rg"
+      max_length = 60
+    }
+    virtual_network = {
+      name = "vnet"
+    }
+  }
+}
+
+variable "address_prefix" {
+  type        = string
+  default     = "10.6.0.0/16"
+  description = "The address space that is used by the virtual network."
+}
+
+variable "sku_name" {
+  type        = string
+  description = <<EOT
+    String consisting of two parts separated by an underscore. The fist part is the name, valid values include: Developer,
+    Basic, Standard and Premium. The second part is the capacity. Default is Developer_1.
+  EOT
+  default     = "Developer_1"
+}
+
+variable "publisher_name" {
+  type        = string
+  description = "The name of publisher/company."
+}
+
+variable "publisher_email" {
+  type        = string
+  description = "The email of publisher/company."
+}
+
+variable "public_network_access_enabled" {
+  description = <<EOT
+    Should the API Management Service be accessible from the public internet?
+    This option is applicable only to the Management plane, not the API gateway or Developer portal.
+    It is required to be true on the creation.
+    For sku=Developer/Premium and network_type=Internal, it must be true.
+    It can only be set to false if there is at least one approve private endpoint connection.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "virtual_network_type" {
+  type        = string
+  description = <<EOT
+    The type of virtual network you want to use, valid values include: None, External, Internal.
+    External and Internal are only supported in the SKUs - Premium and Developer
+  EOT
+  default     = "None"
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/private/versions.tf
+++ b/examples/private/versions.tf
@@ -1,0 +1,22 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.67"
+    }
+  }
+}

--- a/examples/private/versions.tf
+++ b/examples/private/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.67"
+      version = "~>3.117"
     }
   }
 }

--- a/examples/public_serverless/README.md
+++ b/examples/public_serverless/README.md
@@ -19,7 +19,7 @@ provider "azurerm" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.67 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.117 |
 
 ## Providers
 

--- a/examples/public_serverless/versions.tf
+++ b/examples/public_serverless/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.67"
+      version = "~>3.117"
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -24,8 +24,9 @@ locals {
 
   create_ip_address = (
     (startswith(var.sku_name, "Developer") || startswith(var.sku_name, "Premium"))
+    && contains(["External", "Internal"], var.virtual_network_type)
     && length(var.virtual_network_configuration) > 0
-  ) ? true : false
+  )
 
   default_apim_nsg_rules = [
     {

--- a/tests/post_deploy_functional/main_test.go
+++ b/tests/post_deploy_functional/main_test.go
@@ -33,6 +33,10 @@ func TestApiManagementModule(t *testing.T) {
 		SetTestConfigFileName(infraTFVarFileNameDefault).
 		SetTestSpecificFlags(map[string]types.TestFlags{
 			// identity_ids changes from `null` to `[]` after the apply
+			"private": {
+				"IS_TERRAFORM_IDEMPOTENT_APPLY": false,
+				"SKIP_TEST":                     false,
+			},
 			"public_serverless": {
 				"IS_TERRAFORM_IDEMPOTENT_APPLY": false,
 				"SKIP_TEST":                     false,

--- a/tests/post_deploy_functional_readonly/main_test.go
+++ b/tests/post_deploy_functional_readonly/main_test.go
@@ -33,6 +33,10 @@ func TestApiManagementModule(t *testing.T) {
 		SetTestConfigFileName(infraTFVarFileNameDefault).
 		SetTestSpecificFlags(map[string]types.TestFlags{
 			// identity_ids changes from `null` to `[]` after the apply
+			"private": {
+				"IS_TERRAFORM_IDEMPOTENT_APPLY": false,
+				"SKIP_TEST":                     false,
+			},
 			"public_serverless": {
 				"IS_TERRAFORM_IDEMPOTENT_APPLY": false,
 				"SKIP_TEST":                     false,

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.67"
+      version = "~>3.117"
     }
   }
 }


### PR DESCRIPTION
the `public_ip_address` output was giving an error when using `Developer` or `Premium` tier

also adds additional logic so that `Developer` and `Premium` tier may be deployed without vnet injection

adds an example for a private APIM injected into a vnet (`Internal` mode)
- this test takes a long time to run (~45 mins)
