### PR TITLE
fix resource names bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,13 +34,14 @@ module "resource_names_v2" {
 
   for_each = local.use_v2_resource_names ? var.resource_names_map : {}
 
+  logical_product_family  = var.product_family
+  logical_product_service = var.product_service
   region                  = join("", split("-", var.region))
   class_env               = var.environment
   cloud_resource_type     = each.value.name
-  instance_env            = var.resource_number
+  instance_env            = var.environment_number
+  instance_resource       = var.resource_number
   maximum_length          = each.value.max_length
-  logical_product_family  = var.product_family
-  logical_product_service = var.product_service
   use_azure_region_abbr   = true
 }
 


### PR DESCRIPTION
the module is using the `resource_number` as the `environment_instance`, and the actual `resource_number` is always set to 000